### PR TITLE
Extract column length limit as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,7 @@ async function extractColumns(schemaName, tableOrViewName, db) {
       name: column.column_name,
       parent: relationsMap[column.column_name],
       indices: indexMap[column.column_name] || [],
+      maxLength: column.character_maximum_length,
       nullable: column.is_nullable === 'YES',
       defaultValue: column.column_default,
       isPrimary: !!R.find(

--- a/index.js
+++ b/index.js
@@ -127,6 +127,7 @@ async function extractColumns(schemaName, tableOrViewName, db) {
         indexMap[column.column_name] || []
       ),
       type: column.udt_name,
+      rawInfo: column,
       ...parseComment(commentMap[column.column_name]),
     }),
     dbColumns


### PR DESCRIPTION
Hi!

I was trying to add a rule that recommends to remove size limit in `VARCHAR` columns for schemalint, but turns out there is no maximum length info coming from this gem. 

So I figured adding it along with passing all info in `rawInfo` field would be helpful.