### PR TITLE
Support composite types

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,14 +178,15 @@ Views have exactly the same shape as tables.
 
 ### Type
 
-The second property in the result is the `types` array. This contains the user-specified types, currently only postgres [enum](https://www.postgresql.org/docs/9.2/datatype-enum.html) types.
-A type could look like this:
+The second property in the result is the `types` array. This contains the user-specified types, currently only postgres [enum](https://www.postgresql.org/docs/9.2/datatype-enum.html) types and [composite](https://www.postgresql.org/docs/9.2/rowtypes.html).
+An enum type could look like this:
 
 ```javascript
 {
   "type": "enum",
   "name": "AccountState",
   "comment": "Determines the state of an account",
+  "tags": {},
   "values": [
     "active",
     "pending",
@@ -201,5 +202,82 @@ CREATE TYPE "AccountState" AS ENUM ('active', 'pending', 'closed');
 
 COMMENT ON TYPE "AccountState" IS 'Determines the state of an account';
 ```
+
+A composite type could look like this:
+
+```javascript
+{
+  "type": "composite",
+  "name": "AccountData",
+  "comment": "Commonly used data for an account",
+  "tags": {},
+  "attributes": [
+    {
+      "name": "id",
+      "maxLength": null,
+      "nullable": true,
+      "defaultValue": null,
+      "type": "uuid",
+      "tags": {},
+      "rawInfo": {...}
+    },
+    {
+      "name": "name",
+      "maxLength": null,
+      "nullable": true,
+      "defaultValue": null,
+      "type": "text",
+      "tags": {},
+      "rawInfo": {...}
+    },
+    {
+      "name": "status",
+      "maxLength": null,
+      "nullable": true,
+      "defaultValue": null,
+      "type": "AccountState",
+      "tags": {},
+      "rawInfo": {...}
+    },
+    {
+      "name": "address",
+      "maxLength": null,
+      "nullable": true,
+      "defaultValue": null,
+      "type": "jsonb",
+      "tags": {},
+      "rawInfo": {...}
+    }
+  ]
+}
+```
+
+This would be the output if you had created the type with the following:
+
+```SQL
+CREATE TYPE "AccountData" AS (
+  id      UUID,
+  name    TEXT,
+  status  "AccountState",
+  address JSONB
+);
+
+COMMENT ON TYPE "AccountData" IS 'Commonly used data for an account';
+```
+
+### Attributes
+
+The `attributes` array on a `type=composite` has the following properties:
+
+- `name` which is the attribute name,
+- `maxLength`, which specifies the max string length the attribute has if that applies.
+- `nullable` which indicates if the attribute is nullable,
+- `defaultValue` which states the possible default value for the attribute,
+- `type` which specifies the [datatype](https://www.postgresql.org/docs/9.5/datatype.html) of the attribute
+- `comment` which specifies the attribute comment.
+- `tags` which is a map of tags parsed from the attribute comment
+- `rawInfo` which contains all the attribute information that is extracted from postgres.
+
+Type attribute comments work the same way as table column comments.
 
 For an example of a generated object, take a look at [dvdrental.json](./dvdrental.json) file which is generated from the [sample Database](https://www.postgresqltutorial.com/postgresql-sample-database/) from www.postgresqltutorial.com.

--- a/src/extract-attributes.js
+++ b/src/extract-attributes.js
@@ -1,0 +1,56 @@
+import R from 'ramda';
+import { Knex } from 'knex'; // import type
+import parseComment from './parseComment';
+
+/**
+ * @typedef {{ name: string, maxLength: number, nullable: boolean, defaultValue: any, type: string, comment: string, tags: TagMap, rawInfo: object }} Attribute
+ */
+
+/**
+ * @param {string} schemaName
+ * @param {string} typeName
+ * @param {Knex<any, unknown[]>} db
+ * @returns {Promise<Attribute[]>}
+ */
+async function extractAttributes(schemaName, typeName, db) {
+  const dbAttributes = await db
+    .select(
+      db.raw(
+        `*, ('"' || "attribute_udt_schema" || '"."' || "attribute_udt_name" || '"')::regtype as regtype`
+      )
+    )
+    .from('information_schema.attributes')
+    .where('udt_schema', schemaName)
+    .where('udt_name', typeName);
+
+  const commentsQuery = await db.schema.raw(`
+      SELECT cols.attribute_name, pg_catalog.col_description(c.oid, cols.ordinal_position::int)
+      FROM pg_catalog.pg_class c, information_schema.attributes cols
+      WHERE cols.udt_schema = '${schemaName}' AND cols.udt_name = '${typeName}' AND cols.udt_name = c.relname;
+    `);
+  const commentMap = R.pluck(
+    'col_description',
+    R.indexBy(R.prop('attribute_name'), commentsQuery.rows)
+  );
+
+  const attributes = R.map(
+    /** @returns {Attribute} */
+    (attribute) => ({
+      name: attribute.attribute_name,
+      maxLength: attribute.character_maximum_length,
+      nullable: attribute.is_nullable === 'YES',
+      defaultValue: attribute.attribute_default,
+      type:
+        attribute.data_type === 'ARRAY'
+          ? attribute.regtype
+          : attribute.attribute_udt_name,
+      ...parseComment(commentMap[attribute.attribute_name]),
+      rawInfo: attribute,
+    }),
+    dbAttributes
+  );
+
+  return attributes;
+}
+
+export default extractAttributes;

--- a/src/extract-types.js
+++ b/src/extract-types.js
@@ -1,5 +1,6 @@
 import { Knex } from 'knex'; // import type
 import R from 'ramda';
+import extractAttributes from './extract-attributes';
 import parseComment from './parseComment';
 
 /**
@@ -21,12 +22,7 @@ async function extractTypes(schemaName, db) {
   }
   const enumTypes = await enumsQuery;
   for (const enumType of enumTypes) {
-    const typeCommentQuery = await db.schema.raw(
-      `SELECT obj_description(${enumType.oid})`
-    );
-    const rawTypeComment =
-      typeCommentQuery.rows.length > 0 &&
-      typeCommentQuery.rows[0].obj_description;
+    const rawTypeComment = await getTypeRawComment(enumType.oid, db);
     const values = await db
       .select(['enumlabel', 'enumsortorder'])
       .from('pg_enum')
@@ -39,7 +35,49 @@ async function extractTypes(schemaName, db) {
     });
   }
 
+  const compositeTypesQuery = db
+    .select(['t.oid', 't.typname'])
+    .from('pg_type as t')
+    .join('pg_namespace as n', 'n.oid', 't.typnamespace')
+    .join('pg_class as c', 'c.reltype', 't.oid')
+    .where('t.typtype', 'c')
+    .andWhere('c.relkind', 'c');
+  if (schemaName) {
+    compositeTypesQuery.andWhere('n.nspname', schemaName);
+  }
+  const compositeTypes = await compositeTypesQuery;
+  for (const compositeType of compositeTypes) {
+    const rawTypeComment = await getTypeRawComment(compositeType.oid, db);
+    const attributes = await extractAttributes(
+      schemaName,
+      compositeType.typname,
+      db
+    );
+
+    types.push({
+      type: 'composite',
+      name: compositeType.typname,
+      ...parseComment(rawTypeComment),
+      attributes,
+    });
+  }
+
   return types;
+}
+
+/**
+ * @param oid: number
+ * @param {Knex<any, unknown[]>} db
+ * @return {Promise<string|undefined>}
+ */
+async function getTypeRawComment(oid, db) {
+  const typeCommentQuery = await db.schema.raw(
+    `SELECT obj_description(${oid})`
+  );
+  const rawTypeComment =
+    typeCommentQuery.rows.length > 0 &&
+    typeCommentQuery.rows[0].obj_description;
+  return rawTypeComment;
 }
 
 export default extractTypes;

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,18 @@ export type Column = {
   rawInfo: object;
 };
 
+export type Attribute = {
+  name: string;
+
+  maxLength: number;
+  nullable: boolean;
+  defaultValue: any;
+  type: string;
+  comment: string;
+  tags: TagMap;
+  rawInfo: object;
+};
+
 export type TableOrView = {
   name: string;
   columns: Column[];
@@ -47,10 +59,20 @@ export type TableOrView = {
   tags: TagMap;
 };
 
-export type Type = {
+export type Type = EnumType | CompositeType;
+
+export type EnumType = {
   name: string;
-  type: string;
+  type: 'enum';
   values: string[];
+  comment: string;
+  tags: TagMap;
+};
+
+export type CompositeType = {
+  name: string;
+  type: 'composite';
+  attributes: Attribute[];
   comment: string;
   tags: TagMap;
 };


### PR DESCRIPTION
Groundwork to address [#123](https://github.com/kristiandupont/kanel/issues/123).

Add composite types to the types array.

Type and Readme updated as well.

Here is my proposed (TS breaking) change:

```ts
export type Type = EnumType | CompositeType;

export type EnumType = {
  name: string;
  type: 'enum';
  values: string[];
  comment: string;
  tags: TagMap;
};

export type CompositeType = {
  name: string;
  type: 'composite';
  attributes: Attribute[];
  comment: string;
  tags: TagMap;
};

export type Attribute = {
  name: string;

  maxLength: number;
  nullable: boolean;
  defaultValue: any;
  type: string;
  comment: string;
  tags: TagMap;
  rawInfo: object;
};
```