### PR TITLE
FIX:  Kanel #183 - ignore partition types

### DIFF
--- a/src/extract-columns.js
+++ b/src/extract-columns.js
@@ -55,7 +55,8 @@ FROM
   AND att.attnum = con.child
   JOIN pg_class cl ON cl.oid = con.confrelid
   JOIN pg_attribute att2 ON att2.attrelid = con.conrelid
-  AND att2.attnum = con.parent;
+  AND att2.attnum = con.parent
+  where cl.relispartition = false;
     `);
   const relationsMap = R.indexBy(R.prop('column_name'), relationsQuery.rows);
   const parentMap = R.pluck('parent', relationsMap);

--- a/src/extract-tables.js
+++ b/src/extract-tables.js
@@ -9,10 +9,13 @@ import parseComment from './parse-comment';
 async function extractTables(schemaName, db) {
   /** @type {import('./types').TableOrView[]} */
   const tables = [];
+  // Exclude partition tables
   const dbTables = await db
     .select('tablename')
     .from('pg_catalog.pg_tables')
-    .where('schemaname', schemaName);
+    .join('pg_catalog.pg_class', 'tablename', '=', 'pg_class.relname')
+    .where('schemaname', schemaName)
+    .andWhere('relispartition', '=', false)
 
   for (const table of dbTables) {
     const tableName = table.tablename;

--- a/src/extract-tables.js
+++ b/src/extract-tables.js
@@ -15,7 +15,7 @@ async function extractTables(schemaName, db) {
     .from('pg_catalog.pg_tables')
     .join('pg_catalog.pg_class', 'tablename', '=', 'pg_class.relname')
     .where('schemaname', schemaName)
-    .andWhere('relispartition', '=', false)
+    .andWhere('relispartition', '=', false);
 
   for (const table of dbTables) {
     const tableName = table.tablename;

--- a/src/integration-tests/index.test.js
+++ b/src/integration-tests/index.test.js
@@ -228,7 +228,11 @@ CREATE VIEW some_schema.v AS SELECT * FROM some_schema.source;
    CREATE TABLE test_a PARTITION OF test FOR VALUES IN ('a')
  ;`);
       await db.destroy();
-      let extracted = await extractSchema('partition_test', connection, false);
+      const extracted = await extractSchema(
+        'partition_test',
+        connection,
+        false
+      );
 
       expect(extracted.tables).toHaveLength(1);
     });

--- a/src/integration-tests/index.test.js
+++ b/src/integration-tests/index.test.js
@@ -215,22 +215,22 @@ CREATE VIEW some_schema.v AS SELECT * FROM some_schema.source;
     });
   });
 
-  //   describe('Partitions', () => {
-  //     it('Should create only one object per table even if there are partitions', async () => {
-  //       const db = require('knex')(config);
-  //       await db.raw(`CREATE SCHEMA partition_test
-  //     CREATE TABLE test (
-  //       id SERIAL,
-  //       type TEXT NOT NULL,
-  //       PRIMARY KEY(id, type)
-  //     ) PARTITION BY LIST(type)
+  describe('Partitions', () => {
+    it('Should create only one object per table even if there are partitions', async () => {
+      const db = require('knex')(config);
+      await db.raw(`CREATE SCHEMA partition_test
+   CREATE TABLE test (
+     id SERIAL,
+     type TEXT NOT NULL,
+     PRIMARY KEY(id, type)
+   ) PARTITION BY LIST(type)
 
-  //     CREATE TABLE test_a PARTITION OF test FOR VALUES IN ('a')
-  //   ;`);
-  //       await db.destroy();
-  //       let extracted = await extractSchema('partition_test', connection, false);
+   CREATE TABLE test_a PARTITION OF test FOR VALUES IN ('a')
+ ;`);
+      await db.destroy();
+      let extracted = await extractSchema('partition_test', connection, false);
 
-  //       expect(extracted.tables).toHaveLength(1);
-  //     });
-  //   });
+      expect(extracted.tables).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
Ignore partition tables and their columns.

Fixes failing unit test.