### PR TITLE
feat: added ability to extract selected tables

### DIFF
--- a/src/extract-tables.js
+++ b/src/extract-tables.js
@@ -4,11 +4,12 @@ import parseComment from './parse-comment';
 /**
  * @param {string} schemaName
  * @param {import('knex').Knex<any, unknown[]>} db
+ * @param {string[]} tables
  * @returns {Promise<import('./types').TableOrView[]>}
  */
-async function extractTables(schemaName, db) {
+async function extractTables(schemaName, db, tables = []) {
   /** @type {import('./types').TableOrView[]} */
-  const tables = [];
+  const extractedTables = [];
   // Exclude partition tables
   const dbTables = await db
     .select('tablename')
@@ -16,7 +17,12 @@ async function extractTables(schemaName, db) {
     .from('pg_catalog.pg_tables')
     .join('pg_catalog.pg_class', 'tablename', '=', 'pg_class.relname')
     .where('schemaname', schemaName)
-    .andWhere('relispartition', '=', false);
+    .andWhere('relispartition', '=', false)
+    .modify((q) => {
+      if (!tables.length) return;
+
+      q.whereIn('tablename', tables);
+    });
 
   for (const table of dbTables) {
     const tableName = table.tablename;
@@ -29,14 +35,14 @@ async function extractTables(schemaName, db) {
 
     const columns = await extractColumns(schemaName, tableName, db);
 
-    tables.push({
+    extractedTables.push({
       name: tableName,
       ...parseComment(rawTableComment),
       columns,
     });
   }
 
-  return tables;
+  return extractedTables;
 }
 
 export default extractTables;


### PR DESCRIPTION
### Preamble

First of all I want to thank you for all your great work. I'm currently using your library in my project. At the beginning, it's super fast and super snappy. Until it reached a level where I have so many tables in my project and it kinda slow to query all the informations. I found that I don't need to extract all table informations. All I need is a specific tables that changed.

### What's changed
The basic API remains the same, by default it will extract all tables. But if you give a 4th argument to the `extractSchema` function, it will pick the desired tables to be extracted.

Here's the updated function:

```ts
type extractSchema = (
  schemaName: string,
  connectionConfig: string | ConnectionConfig,
  resolveViews: boolean,
  tables?: string[]
) => Promise<Schema>
```

### Improvements

Using this approach it takes a massive amount of improvement in my case:
| All tables | Selected tables (1) | Selected tables (3) | Selected tables (5) |
|-|-|-|-|
| 14.651s | 1.377s | 1.496s | 1.574s |