### PR TITLE
Support view definitions with WITH clauses

### DIFF
--- a/src/kinds/parseViewDefinition.test.ts
+++ b/src/kinds/parseViewDefinition.test.ts
@@ -196,7 +196,7 @@ describe("parseViewDefinition", () => {
     ]);
   });
 
-  it("should resolve kanel#481", () => {
+  it("should work with a minimalistic WITH clause", () => {
     const query = `
     WITH RECURSIVE hierarchy_cte AS (
       SELECT posting.date,
@@ -204,12 +204,6 @@ describe("parseViewDefinition", () => {
          posting.amount
         FROM posting
           JOIN account ON account.id = posting.account_id
-     UNION ALL
-      SELECT hierarchy_cte_1.date,
-         trim_array(hierarchy_cte_1.account, 1) AS account,
-         hierarchy_cte_1.amount
-        FROM hierarchy_cte hierarchy_cte_1
-       WHERE array_length(hierarchy_cte_1.account, 1) > 1
      )
     SELECT hierarchy_cte.date,
     hierarchy_cte.account,
@@ -247,7 +241,7 @@ describe("parseViewDefinition", () => {
     ]);
   });
 
-  it("should work with a minimalistic WITH clause", () => {
+  it("should resolve kanel#481", () => {
     const query = `
     WITH RECURSIVE hierarchy_cte AS (
       SELECT posting.date,
@@ -255,6 +249,12 @@ describe("parseViewDefinition", () => {
          posting.amount
         FROM posting
           JOIN account ON account.id = posting.account_id
+     UNION ALL
+      SELECT hierarchy_cte_1.date,
+         trim_array(hierarchy_cte_1.account, 1) AS account,
+         hierarchy_cte_1.amount
+        FROM hierarchy_cte hierarchy_cte_1
+       WHERE array_length(hierarchy_cte_1.account, 1) > 1
      )
     SELECT hierarchy_cte.date,
     hierarchy_cte.account,

--- a/src/kinds/parseViewDefinition.ts
+++ b/src/kinds/parseViewDefinition.ts
@@ -28,11 +28,13 @@ function parseSelectStmt(
 
   const viewReferences: ViewReference[] = [];
 
+  // eslint-disable-next-line unicorn/no-array-for-each
   selectAst.fromClause.forEach((fromClause: any) => {
     const fromTable = fromClause.RangeVar;
 
     const selectTargets = jp.query(selectAst, "$.targetList[*].ResTarget");
 
+    // eslint-disable-next-line unicorn/no-array-for-each
     selectTargets.forEach((selectTarget: any) => {
       const fields = jp.query(selectTarget, "$.val[*].fields[*].String.str");
       let sourceTable = fromTable?.relname;

--- a/src/kinds/parseViewDefinition.ts
+++ b/src/kinds/parseViewDefinition.ts
@@ -74,8 +74,6 @@ function parseViewDefinition(
   const ast = pgQuery.parse(selectStatement).parse_tree[0];
   const selectAst = ast.RawStmt?.stmt?.SelectStmt;
 
-  console.log(JSON.stringify(selectAst, null, 2));
-
   if (!selectAst) {
     throw new Error(
       `The string '${selectStatement}' doesn't parse as a select statement.`,


### PR DESCRIPTION
This expands on the view resolution logic to support more complex queries, including ones with WITH clauses.

This is necessary to resolve https://github.com/kristiandupont/kanel/issues/481