### PR TITLE
Fix #481, Don't extract indices from another schema

### DIFF
--- a/src/kinds/query-parts/indexMapQueryPart.ts
+++ b/src/kinds/query-parts/indexMapQueryPart.ts
@@ -10,14 +10,17 @@ const indexMapQueryPart = `
     pg_class t,
     pg_class i,
     pg_index ix,
-    pg_attribute a
+    pg_attribute a,
+    pg_namespace n
   WHERE
     t.oid = ix.indrelid
     AND i.oid = ix.indexrelid
     AND a.attrelid = t.oid
+    AND n.oid = t.relnamespace
     AND a.attnum = ANY (ix.indkey)
     AND t.relkind = 'r'
     AND t.relname = :table_name
+    AND n.nspname = :schema_name
   GROUP BY
     a.attname
 `;


### PR DESCRIPTION
This PR fixes #481. It adds a condition that filters indices by schema to `indexMapQueryPart`.