### PR TITLE
Update pg-query-emscripten to 5.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "jsonpath": "^1.1.1",
         "knex": "3.1.0",
         "pg": "8.13.0",
-        "pg-query-emscripten": "^0.1.0",
+        "pg-query-emscripten": "^5.1.0",
         "ramda": "^0.30.0",
         "tagged-comment-parser": "^1.3.3"
       },
@@ -10651,7 +10651,9 @@
       "license": "MIT"
     },
     "node_modules/pg-query-emscripten": {
-      "version": "0.1.0",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/pg-query-emscripten/-/pg-query-emscripten-5.1.0.tgz",
+      "integrity": "sha512-H1ZWOzLRddmHuE4GZqFjjo55hA9zMiePz/WDDGANA/EnvILCJps9pcRucyGd+MFvapeYOy6TWSYz6DbtBOaxRQ==",
       "license": "MIT"
     },
     "node_modules/pg-types": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jsonpath": "^1.1.1",
     "knex": "3.1.0",
     "pg": "8.13.0",
-    "pg-query-emscripten": "^0.1.0",
+    "pg-query-emscripten": "^5.1.0",
     "ramda": "^0.30.0",
     "tagged-comment-parser": "^1.3.3"
   },

--- a/src/kinds/parseViewDefinition.test.ts
+++ b/src/kinds/parseViewDefinition.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, it } from "vitest";
 import parseViewDefinition from "./parseViewDefinition";
 
 describe("parseViewDefinition", () => {
-  it("should understand a trivial select", () => {
+  it("should understand a trivial select", async () => {
     const query = `SELECT id FROM service`;
 
-    const def = parseViewDefinition(query, "public");
+    const def = await parseViewDefinition(query, "public");
     expect(def).toEqual([
       {
         viewColumn: "id",
@@ -19,10 +19,10 @@ describe("parseViewDefinition", () => {
     ]);
   });
 
-  it("should understand a select with explicit schema", () => {
+  it("should understand a select with explicit schema", async () => {
     const query = `SELECT id FROM store.service`;
 
-    const def = parseViewDefinition(query, "public");
+    const def = await parseViewDefinition(query, "public");
     expect(def).toEqual([
       {
         viewColumn: "id",
@@ -35,7 +35,7 @@ describe("parseViewDefinition", () => {
     ]);
   });
 
-  it("should understand a select with join", () => {
+  it("should understand a select with join", async () => {
     const query = `SELECT service.id,
     service."createdAt",
     service.name,
@@ -43,7 +43,7 @@ describe("parseViewDefinition", () => {
    FROM service
      LEFT JOIN "oauthConnection" ON service."oauthConnectionId" = "oauthConnection".id;`;
 
-    const def = parseViewDefinition(query, "public");
+    const def = await parseViewDefinition(query, "public");
     expect(def).toEqual([
       {
         viewColumn: "id",
@@ -80,14 +80,14 @@ describe("parseViewDefinition", () => {
     ]);
   });
 
-  it("should work with multiple schemas and with aliases", () => {
+  it("should work with multiple schemas and with aliases", async () => {
     const query = `
     select u.id as uid, um.id as umid 
       from test1.users u 
       join test2.user_managers um 
       on um.user_id = u.id;`;
 
-    const def = parseViewDefinition(query, "public");
+    const def = await parseViewDefinition(query, "public");
     expect(def).toEqual([
       {
         viewColumn: "uid",
@@ -108,7 +108,7 @@ describe("parseViewDefinition", () => {
     ]);
   });
 
-  it("should return undefined for unresolvable columns", () => {
+  it("should return undefined for unresolvable columns", async () => {
     const query = `
   SELECT cu.customer_id AS id,
     (cu.first_name::text || ' '::text) || cu.last_name::text AS name,
@@ -127,7 +127,7 @@ describe("parseViewDefinition", () => {
      JOIN city ON a.city_id = city.city_id
      JOIN country ON city.country_id = country.country_id;`;
 
-    const def = parseViewDefinition(query, "public");
+    const def = await parseViewDefinition(query, "public");
     expect(def).toEqual([
       {
         viewColumn: "id",
@@ -196,7 +196,7 @@ describe("parseViewDefinition", () => {
     ]);
   });
 
-  it("should work with a minimalistic WITH clause", () => {
+  it("should work with a minimalistic WITH clause", async () => {
     const query = `
     WITH RECURSIVE hierarchy_cte AS (
       SELECT posting.date,
@@ -211,7 +211,7 @@ describe("parseViewDefinition", () => {
     FROM hierarchy_cte;
     `;
 
-    const def = parseViewDefinition(query, "public");
+    const def = await parseViewDefinition(query, "public");
 
     expect(def).toEqual([
       {
@@ -241,7 +241,7 @@ describe("parseViewDefinition", () => {
     ]);
   });
 
-  it("should resolve kanel#481", () => {
+  it("should resolve kanel#481", async () => {
     const query = `
     WITH RECURSIVE hierarchy_cte AS (
       SELECT posting.date,
@@ -262,7 +262,7 @@ describe("parseViewDefinition", () => {
     FROM hierarchy_cte;
     `;
 
-    const def = parseViewDefinition(query, "public");
+    const def = await parseViewDefinition(query, "public");
 
     expect(def).toEqual([
       {

--- a/src/pg-query-emscripten.d.ts
+++ b/src/pg-query-emscripten.d.ts
@@ -1,1 +1,1 @@
-declare module "pg-query-emscripten";
+declare module "pg-query-emscripten/pg_query_wasm";


### PR DESCRIPTION
`pg-query-emscripten` has a very annoying [bug](https://github.com/emscripten-core/emscripten/issues/17228) where it prints it's source code on exception. This PR updates`pg-query-emscripten` to the latest version and fixes incompatibilities with the new version.