### PR TITLE
Add support for pglite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "extract-pg-schema",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extract-pg-schema",
-      "version": "5.1.3",
+      "version": "5.1.4",
       "license": "MIT",
       "dependencies": {
         "jsonpath": "^1.1.1",
         "knex": "3.1.0",
+        "knex-pglite": "^0.11.0",
         "pg": "8.13.1",
         "pg-query-emscripten": "^5.1.0",
         "ramda": "^0.30.0",
@@ -740,6 +741,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.15.tgz",
+      "integrity": "sha512-Jiq31Dnk+rg8rMhcSxs4lQvHTyizNo5b269c1gCC3ldQ0sCLrNVPGzy+KnmonKy1ZArTUuXZf23/UamzFMKVaA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -8969,6 +8976,16 @@
         "tedious": {
           "optional": true
         }
+      }
+    },
+    "node_modules/knex-pglite": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/knex-pglite/-/knex-pglite-0.11.0.tgz",
+      "integrity": "sha512-Z3v+vaF8C/VMJll7J2NHqFZo31ijLfYBsHMKU8jTnjfIF0edUonAB3sbAZYmUbSeJDDGfZdJPsvcB4ZyGBERcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@electric-sql/pglite": "^0.2.14",
+        "knex": "3.1.0"
       }
     },
     "node_modules/ky": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "jsonpath": "^1.1.1",
     "knex": "3.1.0",
+    "knex-pglite": "^0.11.0",
     "pg": "8.13.1",
     "pg-query-emscripten": "^5.1.0",
     "ramda": "^0.30.0",

--- a/src/extractSchemas.ts
+++ b/src/extractSchemas.ts
@@ -1,5 +1,6 @@
 import type { Knex } from "knex";
 import knex from "knex";
+import ClientPgLite from "knex-pglite";
 import type { ConnectionConfig } from "pg";
 import * as R from "ramda";
 
@@ -132,7 +133,16 @@ async function extractSchemas(
   options?: ExtractSchemaOptions,
 ): Promise<Record<string, Schema>> {
   const connection = connectionConfig as string | Knex.PgConnectionConfig;
-  const db = knex({ client: "postgres", connection });
+  let db;
+  if (typeof connection === "string" && connection.startsWith("file:")) {
+    db = knex({
+      client: ClientPgLite,
+      dialect: "postgres",
+      connection: { filename: connection.slice("file:".length) },
+    });
+  } else {
+    db = knex({ client: "postgres", connection });
+  }
 
   const q = await db
     .select<{ nspname: string }[]>("nspname")


### PR DESCRIPTION
If the connection string starts with "file:" the specified path is opened using pglite. For example, when providing
`file:my/pglite/db/folder`, the folder 'my/pglite/db/folder' is opened using pglite.

I tested this by applying some DB migrations to a temporary pglite db and then running kanel on this temp pglite db.