### PR TITLE
Update knex-pglite to make pglite a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "knex": "3.1.0",
-        "knex-pglite": "^0.11.0",
+        "knex-pglite": "^0.12.0",
         "pg": "8.16.3",
         "pg-query-emscripten": "^5.1.0",
         "ramda": "^0.31.0",
@@ -588,7 +588,8 @@
     "node_modules/@electric-sql/pglite": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.17.tgz",
-      "integrity": "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw=="
+      "integrity": "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==",
+      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.0",
@@ -8880,12 +8881,13 @@
       }
     },
     "node_modules/knex-pglite": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/knex-pglite/-/knex-pglite-0.11.0.tgz",
-      "integrity": "sha512-Z3v+vaF8C/VMJll7J2NHqFZo31ijLfYBsHMKU8jTnjfIF0edUonAB3sbAZYmUbSeJDDGfZdJPsvcB4ZyGBERcA==",
-      "dependencies": {
-        "@electric-sql/pglite": "^0.2.14",
-        "knex": "3.1.0"
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/knex-pglite/-/knex-pglite-0.12.0.tgz",
+      "integrity": "sha512-EsTpIJ8D1SaFm5sVNqKf+Q57bnPGVEpVWwZXXxGrzDyIwtHOwAnd59dY8izkR/nJt8OFrLHMudqaPKfXajOHsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.x",
+        "knex": "3.x"
       }
     },
     "node_modules/knex/node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "knex": "3.1.0",
-    "knex-pglite": "^0.11.0",
+    "knex-pglite": "^0.12.0",
     "pg": "8.16.3",
     "pg-query-emscripten": "^5.1.0",
     "ramda": "^0.31.0",


### PR DESCRIPTION
knex-pglite had pglite as a direct dependency which was then lock in at an older version. This resulted in two pglite versions in my project, i.e. the old version in kanel and the latest version in my project. However, for some reason this caused a crash when calling kanel (not sure why but I guess because there where two versions)

This should make it possible to only have one pglite version installed.