### PR TITLE
Deterministic View parsing + Enhanced CTE parsing

### DIFF
--- a/src/kinds/parseViewDefinition.ts
+++ b/src/kinds/parseViewDefinition.ts
@@ -1,15 +1,14 @@
 import { last } from "ramda";
 
-let pgQueryInstance: any;
-const getPgQuery = async () => {
-  if (!pgQueryInstance) {
-    // Use eval to prevent TypeScript from converting this to require
-    const pgQueryModule = await eval(
-      'import("pg-query-emscripten/pg_query_wasm.js")',
-    );
-    pgQueryInstance = await new pgQueryModule.default();
-  }
-  return pgQueryInstance;
+// Create a fresh parser instance for each parse call to avoid state corruption
+// The pg-query-emscripten WASM module has internal state that can become
+// corrupted when reused, causing non-deterministic parse failures.
+const createPgQuery = async () => {
+  // Use eval to prevent TypeScript from converting this to require
+  const pgQueryModule = await eval(
+    'import("pg-query-emscripten/pg_query_wasm.js")',
+  );
+  return new pgQueryModule.default();
 };
 
 export type ViewReference = {
@@ -30,9 +29,32 @@ function parseSelectStmt(
 ): ViewReference[] {
   if (selectAst.larg && selectAst.rarg) {
     // This is a UNION, INTERSECT, or EXCEPT operation
+    // Each branch may have its own aliases, so extract them for each branch
+    const lArgAliases = findAliasDefinitions(selectAst.larg);
+    const lLocalAliases = Object.fromEntries(
+      lArgAliases.map(({ schemaname, relname, alias }) => [
+        alias.aliasname,
+        { schema: schemaname, table: relname },
+      ]),
+    );
+
+    const rArgAliases = findAliasDefinitions(selectAst.rarg);
+    const rLocalAliases = Object.fromEntries(
+      rArgAliases.map(({ schemaname, relname, alias }) => [
+        alias.aliasname,
+        { schema: schemaname, table: relname },
+      ]),
+    );
+
     return [
-      ...parseSelectStmt(selectAst.larg, defaultSchema, aliases),
-      ...parseSelectStmt(selectAst.rarg, defaultSchema, aliases),
+      ...parseSelectStmt(selectAst.larg, defaultSchema, {
+        ...aliases,
+        ...lLocalAliases,
+      }),
+      ...parseSelectStmt(selectAst.rarg, defaultSchema, {
+        ...aliases,
+        ...rLocalAliases,
+      }),
     ];
   }
 
@@ -139,11 +161,58 @@ function findAliasDefinitions(node: any): {
   return aliasDefinitions;
 }
 
+/**
+ * Recursively resolve a ViewReference through CTEs until we reach an actual table.
+ * This handles nested CTEs where CTE A references CTE B which references a real table.
+ */
+function resolveCteThroughChain(
+  viewRef: ViewReference,
+  cteAliases: Record<string, ViewReference[]>,
+  visited: Set<string> = new Set(),
+): ViewReference {
+  const source = viewRef.source;
+  if (!source) {
+    return viewRef;
+  }
+
+  // Check if this source table is a CTE
+  if (!(source.table in cteAliases)) {
+    // Not a CTE, this is the final source (actual table)
+    return viewRef;
+  }
+
+  // Prevent infinite loops in case of circular CTE references
+  const cteKey = `${source.table}:${source.column}`;
+  if (visited.has(cteKey)) {
+    return viewRef;
+  }
+  visited.add(cteKey);
+
+  // Find the corresponding column in the CTE
+  const cteColumns = cteAliases[source.table];
+  const cteColumn = cteColumns.find((col) => col.viewColumn === source.column);
+
+  if (!cteColumn) {
+    // Column not found in CTE, return as-is
+    return viewRef;
+  }
+
+  // Recursively resolve through the CTE chain
+  const resolvedCte = resolveCteThroughChain(cteColumn, cteAliases, visited);
+
+  // Return a new ViewReference with the original viewColumn but resolved source
+  return {
+    viewColumn: viewRef.viewColumn,
+    source: resolvedCte.source,
+  };
+}
+
 async function parseViewDefinition(
   selectStatement: string,
   defaultSchema: string,
 ): Promise<ViewReference[]> {
-  const pgQuery = await getPgQuery();
+  // Create a fresh parser instance for each call to avoid state corruption
+  const pgQuery = await createPgQuery();
   const ast = pgQuery.parse(selectStatement).parse_tree.stmts[0];
   const selectAst = ast?.stmt?.SelectStmt;
 
@@ -165,37 +234,83 @@ async function parseViewDefinition(
 
   const cteAliases: Record<string, ViewReference[]> = {};
 
+  // Process CTEs in order (earlier CTEs can be referenced by later ones)
   for (const cte of withClauses) {
     if (cte.CommonTableExpr) {
-      const alias = cte.CommonTableExpr.ctename;
-      const cteQuery = cte.CommonTableExpr.ctequery.SelectStmt;
+      const cteName = cte.CommonTableExpr.ctename;
+      const cteQueryObj = cte.CommonTableExpr.ctequery;
+      const cteQuery = cteQueryObj?.SelectStmt;
+
+      // Check if this is a VALUES clause CTE (inline table)
+      // VALUES clauses have a SelectStmt with valuesLists but no fromClause or targetList
+      if (cteQuery?.valuesLists && !cteQuery?.fromClause) {
+        // This is a VALUES-based CTE like: relationships AS (VALUES (...), (...))
+        // The columns are named column1, column2, etc. and have no real source
+        // Register them with undefined source so resolution treats them as terminals
+        const valuesLists = cteQuery.valuesLists;
+        if (valuesLists.length > 0) {
+          // valuesLists[0] is { List: { items: [...] } } structure
+          const firstRow = valuesLists[0]?.List?.items;
+          const numColumns = firstRow?.length ?? 0;
+          const valuesCteColumns: ViewReference[] = [];
+          for (let i = 1; i <= numColumns; i++) {
+            valuesCteColumns.push({
+              viewColumn: `column${i}`,
+              source: undefined, // VALUES columns have no source table
+            });
+          }
+          cteAliases[cteName] = valuesCteColumns;
+        }
+        continue;
+      }
 
       if (!cteQuery) {
         continue;
       }
 
-      // Process the CTE query recursively
-      const cteAlias = parseSelectStmt(cteQuery, defaultSchema, aliases);
+      // Find aliases within this CTE's query
+      const cteQueryAliases = findAliasDefinitions(cteQuery);
+      const cteLocalAliases = Object.fromEntries(
+        cteQueryAliases.map(({ schemaname, relname, alias }) => [
+          alias.aliasname,
+          { schema: schemaname, table: relname },
+        ]),
+      );
 
-      cteAliases[alias] = cteAlias;
+      // Merge global aliases with CTE-local aliases
+      const mergedAliases = { ...aliases, ...cteLocalAliases };
+
+      // Process the CTE query
+      const cteColumns = parseSelectStmt(
+        cteQuery,
+        defaultSchema,
+        mergedAliases,
+      );
+
+      cteAliases[cteName] = cteColumns;
     }
   }
+
+  // Find aliases in the main SELECT
+  const mainSelectAliases = findAliasDefinitions(selectAst);
+  const mainLocalAliases = Object.fromEntries(
+    mainSelectAliases.map(({ schemaname, relname, alias }) => [
+      alias.aliasname,
+      { schema: schemaname, table: relname },
+    ]),
+  );
+  const mergedMainAliases = { ...aliases, ...mainLocalAliases };
 
   const primaryViewReferences = parseSelectStmt(
     selectAst,
     defaultSchema,
-    aliases,
+    mergedMainAliases,
   );
 
-  const viewReferences = primaryViewReferences.map((viewReference) => {
-    const source = viewReference.source;
-    return source && source.table in cteAliases
-      ? (cteAliases[source.table].find(
-          (cteViewReference) =>
-            cteViewReference.viewColumn === viewReference.viewColumn,
-        ) as ViewReference)
-      : viewReference;
-  });
+  // Resolve each view reference through the CTE chain
+  const viewReferences = primaryViewReferences.map((viewReference) =>
+    resolveCteThroughChain(viewReference, cteAliases),
+  );
 
   return viewReferences;
 }


### PR DESCRIPTION
This PR addresses a complex non-determinism bug regarding parsing views and improves view parsing to support more complex view definitions.

## Deterministic Bug
I use Kanel in a complex project with many schemas, views, where they are often similarly named too. At some point I noticed that Kanel kept outputting slightly different results. It would stop detecting some brand IDs on a run, and it'd do this randomly for my various views.

Initially I thought it may be due to how we query the schema from the DB since they lack "ORDER BY" statements, but it turns out its the WASM AST parser we are using. By making sure we never reuse the parser, rather always import a new one, we then get consistent view parsing regardless of complexity.

## CTE Parsing
While at it, especially thanks to LLM coding, I added a few improvements to CTE parsing. Basically, before this library would not parse complex CTEs properly, with nesting and various alias naming. It does now.

It also didn't properly handle UNION queries, including recursive queries, which it does now.

Lastly, if you used a trick of creating an inline table of VALUES, it also could not parse it and understand what the column types should be. That's also fixed. 

So it should be much more resilient and versatile in view parsing support at this point! 