### PR TITLE
Remove constraint option from clause

### DIFF
--- a/src/kinds/extractTable.test.ts
+++ b/src/kinds/extractTable.test.ts
@@ -200,6 +200,81 @@ describe("extractTable", () => {
     expect(actual).toEqual(expected);
   });
 
+  it("should strip NOT VALID from check constraint clauses without truncating", async () => {
+    const db = getKnex();
+    await db.raw(`create table test.some_table_with_not_valid_check (
+        product TEXT
+    )`);
+    await db.raw(`alter table test.some_table_with_not_valid_check
+        add constraint product_length_check
+        check (product is null or length(product) <= 500) not valid`);
+
+    const result = await extractTable(
+      db,
+      makePgType("some_table_with_not_valid_check"),
+    );
+    const actual = result.checks;
+
+    const expected: TableCheck[] = [
+      {
+        name: "product_length_check",
+        clause: "(product IS NULL) OR (length(product) <= 500)",
+      },
+    ];
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("should strip NO INHERIT from check constraint clauses without truncating", async () => {
+    const db = getKnex();
+    await db.raw(`create table test.some_table_with_no_inherit_check (
+        product TEXT
+    )`);
+    await db.raw(`alter table test.some_table_with_no_inherit_check
+        add constraint product_length_check
+        check (product is null or length(product) <= 500) no inherit`);
+
+    const result = await extractTable(
+      db,
+      makePgType("some_table_with_no_inherit_check"),
+    );
+    const actual = result.checks;
+
+    const expected: TableCheck[] = [
+      {
+        name: "product_length_check",
+        clause: "(product IS NULL) OR (length(product) <= 500)",
+      },
+    ];
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("should strip both NO INHERIT and NOT VALID from check constraint clauses", async () => {
+    const db = getKnex();
+    await db.raw(`create table test.some_table_with_both_attrs_check (
+        product TEXT
+    )`);
+    await db.raw(`alter table test.some_table_with_both_attrs_check
+        add constraint product_length_check
+        check (product is null or length(product) <= 500) no inherit not valid`);
+
+    const result = await extractTable(
+      db,
+      makePgType("some_table_with_both_attrs_check"),
+    );
+    const actual = result.checks;
+
+    const expected: TableCheck[] = [
+      {
+        name: "product_length_check",
+        clause: "(product IS NULL) OR (length(product) <= 500)",
+      },
+    ];
+
+    expect(actual).toEqual(expected);
+  });
+
   it("should handle domains, composite types, ranges and enums as well as arrays of those", async () => {
     const db = getKnex();
     await db.raw("create domain test.some_domain as text");

--- a/src/kinds/extractTable.ts
+++ b/src/kinds/extractTable.ts
@@ -526,13 +526,16 @@ const extractTable = async (
   const checks = checkQuery.rows
     .flatMap((row: any) => row.checks as TableCheck)
     .map(({ name, clause }: TableCheck) => {
+      const endIndex = clause.lastIndexOf(")");
+      const expression =
+        endIndex === -1 ? clause : clause.slice(0, endIndex + 1);
       const numberOfBrackets =
-        clause.startsWith("((") && clause.endsWith("))") ? 2 : 1;
+        expression.startsWith("((") && expression.endsWith("))") ? 2 : 1;
       return {
         name,
-        clause: clause.slice(
+        clause: expression.slice(
           numberOfBrackets,
-          clause.length - numberOfBrackets,
+          expression.length - numberOfBrackets,
         ),
       };
     });


### PR DESCRIPTION
### Issues description
When using `ADD table_constraint [ NOT VALID ]` the checks clause (pg_get_constraintdef) would include "NOT VALID" but due to faulty parenthesis removal logic, it would remove the "D" from "VALID".

Example from test
```diff
-     "clause": "(product IS NULL) OR (length(product) <= 500)",
+     "clause": "((product IS NULL) OR (length(product) <= 500))) NOT VALI",
```

As seen in the example, I propose finding the last parenthesis and stripping everything following it.

Alternatively, `NOT VALID`, `NO INHERIT`, and soon `NOT ENFORCED` should be part of the clause, as it is part of pg_get_constraintdef, but that feels counterintuitive with the "clause" naming.