### PR TITLE
Bump node to 20 for test env

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
The testcontainers devDependency depends on undici@7 that requires Node >= 20
Bumping the Node version for the test runner.