### PR TITLE
Scope the per-table index query to the table being described

### DIFF
--- a/src/kinds/extractTable.ts
+++ b/src/kinds/extractTable.ts
@@ -475,8 +475,13 @@ const extractTable = async (
         ) ORDER BY keys.key_order) AS columns
       FROM
         pg_index ix
+        INNER JOIN pg_class ct ON ct.oid = ix.indrelid
+        INNER JOIN pg_namespace cn ON cn.oid = ct.relnamespace
         CROSS JOIN unnest(ix.indkey) WITH ORDINALITY AS keys(key, key_order)
         LEFT JOIN pg_attribute a ON ix.indrelid = a.attrelid AND key = a.attnum
+      WHERE
+        ct.relname = :table_name
+        AND cn.nspname = :schema_name
       GROUP BY ix.indexrelid, ix.indrelid
     )
     SELECT


### PR DESCRIPTION
`extractTable`'s `indicesQuery` aggregates every index in the database in order to describe one table. The `index_columns` CTE has no `WHERE`, and the outer `relname`/`nspname` filter can't be pushed into it — grouping is on `indexrelid`, the qualifier is on `indrelid`'s table name.

Describing one 11-index table, on a database with 1,044 indexes:

```
before   Seq Scan on pg_index                      (rows=1044)   17.539 ms
after    Index Scan using pg_index_indrelid_index  (rows=11)      0.827 ms
```

It is also a correctness problem. `pg_get_indexdef()` calls `relation_open()`, so evaluating it across every index opens every index — including relations in schemas the caller never asked for, since the CTE ignores the `schemas` option. Anything dropped concurrently aborts the extraction:

```
could not open relation with OID 24235
code: 'XX000', file: 'relation.c', routine: 'relation_open'
```

That surfaces as an intermittent failure when something drops a table while type generation is running.

#481 reported the same bug against the column-level index map and fixed it by joining `pg_class`/`pg_namespace` and filtering on `relname` + `nspname`. `indicesQuery` never got the same treatment; this applies it in the same style.

Results are unchanged — both forms compared across 197 relations and 511 index rows on a live database, hashing each result set, no differences, partial and expression indexes included. The existing suite passes unmodified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index extraction to correctly scope results by table and schema names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->